### PR TITLE
Fix scaleway_ip ip address attribute read

### DIFF
--- a/resource_ip.go
+++ b/resource_ip.go
@@ -40,7 +40,7 @@ func resourceIpRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	d.Set("ip", ip)
+	d.Set("ip", ip.IP.Address)
 	return nil
 }
 


### PR DESCRIPTION
The ip attribute wasn't being updated correctly, fixed to read the address from the IP.
